### PR TITLE
 Make getMatches(final double[] vec, int maxNumMatches) public #6 

### DIFF
--- a/src/main/java/com/medallia/word2vec/Searcher.java
+++ b/src/main/java/com/medallia/word2vec/Searcher.java
@@ -17,6 +17,9 @@ public interface Searcher {
 	/** @return Top matches to the given word */
 	List<Match> getMatches(String word, int maxMatches) throws UnknownWordException;
 	
+	/** @return Top matches to the given vector */
+	List<Match> getMatches(final double[] vec, int maxNumMatches);
+	
 	/** Represents the similarity between two words */
 	public interface SemanticDifference {
 		/** @return Top matches to the given word which share this semantic relationship */

--- a/src/main/java/com/medallia/word2vec/SearcherImpl.java
+++ b/src/main/java/com/medallia/word2vec/SearcherImpl.java
@@ -49,7 +49,7 @@ class SearcherImpl implements Searcher {
 		return normalized.containsKey(word);
 	}
 
-	private List<Match> getMatches(final double[] vec, int maxNumMatches) {
+	@Override public List<Match> getMatches(final double[] vec, int maxNumMatches) {
 		return Match.ORDERING.greatestOf(
 				Iterables.transform(model.vocab, new Function<String, Match>() {
 					@Override

--- a/src/test/java/com/medallia/word2vec/Word2VecTest.java
+++ b/src/test/java/com/medallia/word2vec/Word2VecTest.java
@@ -173,6 +173,7 @@ public class Word2VecTest {
             .type(NeuralNetworkType.SKIP_GRAM)
             .train(testData());
 
+        // This vector defines the word "anarchism" in the given model.
         double[] vectors = new double[] { 0.11410251703652753, 0.271180824514185, 0.03748515103121994, 0.20888126888511183, 0.009713531343874777, 0.4769425625416319, 0.1431890482445165, -0.1917578875330224, -0.33532561802423366,
             -0.08794543238607992, 0.20404593606213406, 0.26170074241479385, 0.10020961212561065, 0.11400571893146201, -0.07846426915175395, -0.19404092647187385, 0.13381991303455204, -4.6749635342694615E-4, -0.0820905789076496,
             -0.30157145455251866, 0.3652037905836543, -0.16466827556950117, -0.012965932276668056, 0.09896568721267748, -0.01925755122093615 };
@@ -181,6 +182,27 @@ public class Word2VecTest {
 
         assertEquals(
                 ImmutableList.of("anarchism", "feminism", "trouble", "left", "capitalism"),
+                Lists.transform(matches, Match.TO_WORD)
+            );
+    }
+  
+  /**
+   * Test that the model can retrieve words by a vector.
+   */
+  @Test
+    public void testGetWordByNotExistantVector() throws InterruptedException, IOException, UnknownWordException {
+        Word2VecModel model = trainer()
+            .type(NeuralNetworkType.SKIP_GRAM)
+            .train(testData());
+
+        double[] vectors = new double[] { 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0 };
+
+        List<Match> matches = model.forSearch().getMatches(vectors, 5);
+
+        assertEquals(
+                ImmutableList.of("the", "of", "and", "in", "a"),
                 Lists.transform(matches, Match.TO_WORD)
             );
     }

--- a/src/test/java/com/medallia/word2vec/Word2VecTest.java
+++ b/src/test/java/com/medallia/word2vec/Word2VecTest.java
@@ -1,5 +1,19 @@
 package com.medallia.word2vec;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.thrift.TException;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -11,36 +25,24 @@ import com.medallia.word2vec.neuralnetwork.NeuralNetworkType;
 import com.medallia.word2vec.thrift.Word2VecModelThrift;
 import com.medallia.word2vec.util.Common;
 import com.medallia.word2vec.util.ThriftUtils;
-import org.apache.commons.io.FileUtils;
-import org.apache.thrift.TException;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-/** 
+/**
  * Tests for {@link Word2VecModel} and related classes.
  * <p>
- * Note that the implementation is expected to be deterministic if numThreads is set to 1
+ * Note that the implementation is expected to be deterministic if numThreads is
+ * set to 1
  */
 public class Word2VecTest {
 	@Rule
 	public ExpectedException expected = ExpectedException.none();
-	
+
 	/** Clean up after a test run */
 	@After
 	public void after() {
 		// Unset the interrupted flag to avoid polluting other tests
 		Thread.interrupted();
 	}
-	
+
 	/** Test {@link NeuralNetworkType#CBOW} */
 	@Test
 	public void testCBOW() throws IOException, TException, InterruptedException {
@@ -57,7 +59,7 @@ public class Word2VecTest {
 						.train(testData())
 		);
 	}
-	
+
 	/** Test {@link NeuralNetworkType#CBOW} with 15 iterations */
 	@Test
 	public void testCBOWwith15Iterations() throws IOException, TException, InterruptedException {
@@ -75,7 +77,7 @@ public class Word2VecTest {
 					.train(testData())
 			);
 	}
-	
+
 	/** Test {@link NeuralNetworkType#SKIP_GRAM} */
 	@Test
 	public void testSkipGram() throws IOException, TException, InterruptedException {
@@ -92,7 +94,7 @@ public class Word2VecTest {
 					.train(testData())
 			);
 	}
-	
+
 	/** Test {@link NeuralNetworkType#SKIP_GRAM} with 15 iterations */
 	@Test
 	public void testSkipGramWith15Iterations() throws IOException, TException, InterruptedException {
@@ -109,7 +111,7 @@ public class Word2VecTest {
 					.train(testData())
 			);
 	}
-	
+
 	/** Test that we can interrupt the huffman encoding process */
 	@Test
 	public void testInterruptHuffman() throws IOException, InterruptedException {
@@ -143,33 +145,54 @@ public class Word2VecTest {
 				})
 			.train(testData());
 	}
-	
-	/** 
-	 * Test the search results are deterministic
-	 * Note the actual values may not make sense since the model we train isn't tuned
-	 */
+
+  /**
+   * Test the search results are deterministic Note the actual values may not
+   * make sense since the model we train isn't tuned
+   */
 	@Test
 	public void testSearch() throws InterruptedException, IOException, UnknownWordException {
 		Word2VecModel model = trainer()
 			.type(NeuralNetworkType.SKIP_GRAM)
 			.train(testData());
-		
+
 		List<Match> matches = model.forSearch().getMatches("anarchism", 5);
-		
+
 		assertEquals(
 				ImmutableList.of("anarchism", "feminism", "trouble", "left", "capitalism"),
 				Lists.transform(matches, Match.TO_WORD)
 			);
 	}
 
+  /**
+   * Test that the model can retrieve words by a vector.
+   */
+  @Test
+    public void testGetWordByVector() throws InterruptedException, IOException, UnknownWordException {
+        Word2VecModel model = trainer()
+            .type(NeuralNetworkType.SKIP_GRAM)
+            .train(testData());
+
+        double[] vectors = new double[] { 0.11410251703652753, 0.271180824514185, 0.03748515103121994, 0.20888126888511183, 0.009713531343874777, 0.4769425625416319, 0.1431890482445165, -0.1917578875330224, -0.33532561802423366,
+            -0.08794543238607992, 0.20404593606213406, 0.26170074241479385, 0.10020961212561065, 0.11400571893146201, -0.07846426915175395, -0.19404092647187385, 0.13381991303455204, -4.6749635342694615E-4, -0.0820905789076496,
+            -0.30157145455251866, 0.3652037905836543, -0.16466827556950117, -0.012965932276668056, 0.09896568721267748, -0.01925755122093615 };
+
+        List<Match> matches = model.forSearch().getMatches(vectors, 5);
+
+        assertEquals(
+                ImmutableList.of("anarchism", "feminism", "trouble", "left", "capitalism"),
+                Lists.transform(matches, Match.TO_WORD)
+            );
+    }
+
 	/** Test reading Word2Vec C version txt output format into this library */
 	@Test
 	public void testTxtModelRead() throws IOException, UnknownWordException {
 		String filename = "word2vec.c.output.model.txt";
 		Word2VecModel word2VecModel = Word2VecModel.fromTextFile(filename, Common.readResource(Word2VecTest.class, filename));
-		assertEquals(0.9927725293757652, word2VecModel.forSearch().cosineDistance("three", "five"), 1e-5); 
+    assertEquals(0.9927725293757652, word2VecModel.forSearch().cosineDistance("three", "five"), 1e-5);
 	}
-	
+
 	/** @return {@link Word2VecTrainer} which by default uses all of the supported features */
 	@VisibleForTesting
 	public static Word2VecTrainerBuilder trainer() {
@@ -191,7 +214,7 @@ public class Word2VecTest {
 		Iterable<List<String>> partitioned = Iterables.partition(lines, 1000);
 		return partitioned;
 	}
-	
+
 	private void assertModelMatches(String expectedResource, Word2VecModel model) throws TException {
 		final String thrift;
 		try {
@@ -208,14 +231,14 @@ public class Word2VecTest {
 			}
 			throw new AssertionError("Could not read resource " + expectedResource + " wrote to " + filename);
 		}
-		
+
 		Word2VecModelThrift expected = ThriftUtils.deserializeJson(
 				new Word2VecModelThrift(),
 				thrift
 		);
-		
+
 		assertEquals("Mismatched vocab", expected.getVocab().size(), Iterables.size(model.getVocab()));
-		
+
 		assertEquals(expected, model.toThrift());
 	}
 }


### PR DESCRIPTION
Makes SearcherImpl.getMatches(double[], int) public and exposes it to the interface for matching words by a given vector.
