### PR TITLE
Added license block to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,13 @@
   <groupId>com.medallia.word2vec</groupId>
   <artifactId>medallia-word2vec</artifactId>
   <version>1.0.0</version>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
According the file LICENSE, this project is licensed under MIT License. I added the according block into the pom file, so that Nexus Professional and Apache Maven Project Info Reports Plugin can read it automatically.
https://maven.apache.org/plugins/maven-project-info-reports-plugin/license-mojo.html
