### PR TITLE
Added getter for com.medallia.word2vec.Word2VecModel.layerSize

### DIFF
--- a/src/main/java/com/medallia/word2vec/Word2VecModel.java
+++ b/src/main/java/com/medallia/word2vec/Word2VecModel.java
@@ -57,6 +57,11 @@ public class Word2VecModel {
 		return vocab;
 	}
 
+    /** @return Layer size */
+    public int getLayerSize() {
+        return layerSize;
+    }
+
 	/** @return {@link Searcher} for searching */
 	public Searcher forSearch() {
 		return new SearcherImpl(this);


### PR DESCRIPTION
I need this getter for my further calculations:innocent:
Looks like, you already have one getter for package-local parameters, so this getter not hurt anything:smirk:
So please add it:blush:
