### PR TITLE
Split large model files across multiple buffers.

### DIFF
--- a/src/main/java/com/medallia/word2vec/NormalizedWord2VecModel.java
+++ b/src/main/java/com/medallia/word2vec/NormalizedWord2VecModel.java
@@ -11,7 +11,7 @@ import java.nio.DoubleBuffer;
  * Represents a word2vec model where all the vectors are normalized to unit length.
  */
 public class NormalizedWord2VecModel extends Word2VecModel {
-	private NormalizedWord2VecModel(Iterable<String> vocab, int layerSize, final DoubleBuffer vectors) {
+	private NormalizedWord2VecModel(Iterable<String> vocab, int layerSize, final DoubleBuffer[] vectors) {
 		super(vocab, layerSize, vectors);
 		normalize();
 	}
@@ -22,7 +22,11 @@ public class NormalizedWord2VecModel extends Word2VecModel {
 	}
 
 	public static NormalizedWord2VecModel fromWord2VecModel(Word2VecModel model) {
-		return new NormalizedWord2VecModel(model.vocab, model.layerSize, model.vectors.duplicate());
+		DoubleBuffer[] newVectors = new DoubleBuffer[model.vectors.length];
+		for (int i = 0; i < newVectors.length; i++) {
+			newVectors[i] = model.vectors[i].duplicate();
+		}
+		return new NormalizedWord2VecModel(model.vocab, model.layerSize, newVectors);
 	}
 
 	/** @return {@link NormalizedWord2VecModel} created from a thrift representation */
@@ -36,14 +40,17 @@ public class NormalizedWord2VecModel extends Word2VecModel {
 
 	/** Normalizes the vectors in this model */
 	private void normalize() {
-		for(int i = 0; i < vocab.size(); ++i) {
-			double len = 0;
-			for(int j = i * layerSize; j < (i + 1) * layerSize; ++j)
-				len += vectors.get(j) * vectors.get(j);
-			len = Math.sqrt(len);
+		for(int i = 0; i < vectors.length; ++i) {
+			DoubleBuffer buffer = vectors[i];
+			for(int j = 0; j < Math.min(vectorsPerBuffer, buffer.limit() / layerSize); ++j) {
+				double len = 0;
+				for(int k = j * layerSize; k < (j + 1) * layerSize; ++k)
+					len += buffer.get(k) * buffer.get(k);
+				len = Math.sqrt(len);
 
-			for(int j = i * layerSize; j < (i + 1) * layerSize; ++j)
-				vectors.put(j, vectors.get(j) / len);
+				for(int k = j * layerSize; k < (j + 1) * layerSize; ++k)
+					buffer.put(k, buffer.get(k) / len);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #28 by splitting large models into multiple buffers in memory.

Note on formatting: I used tabs throughout, as that seemed to be more common in the files. `SearcherImpl` was mixed-use. I also tried to keep for-loop (`for(` vs `for (`) and naming similar to the local code. This was mixed-use as well.
