### PR TITLE
fix incorrect vocabs when loading from utf-8 binary

### DIFF
--- a/src/main/java/com/medallia/word2vec/Word2VecModel.java
+++ b/src/main/java/com/medallia/word2vec/Word2VecModel.java
@@ -161,19 +161,24 @@ public class Word2VecModel {
 
 			long lastLogMessage = System.currentTimeMillis();
 			final float[] floats = new float[layerSize];
+
+			ByteBuffer bb = ByteBuffer.allocate(1000);
+			byte b;
 			for (int lineno = 0; lineno < vocabSize; lineno++) {
 				// read vocab
-				sb.setLength(0);
-				c = (char) buffer.get();
+				bb.rewind();
+				b = buffer.get();
+				c = (char)b;
 				while (c != ' ') {
 					// ignore newlines in front of words (some binary files have newline,
 					// some don't)
 					if (c != '\n') {
-						sb.append(c);
+						bb.put(b);
 					}
-					c = (char) buffer.get();
+					b = buffer.get();
+					c = (char)b;
 				}
-				vocabs.add(sb.toString());
+				vocabs.add(new String(bb.array(), 0, bb.position(), Charset.forName("utf-8")));
 
 				// read vector
 				final FloatBuffer floatBuffer = buffer.asFloatBuffer();


### PR DESCRIPTION
Hi. I'm very grateful for your work in porting Word2vec to Java and it's a great job, I think. But I have a trouble when parse UTF-8 binary file (from Vietnamese corpus), the Vocabs was incorrect. So I fixed it by some ugly line of code :D. Review it and turn it to your clean code.
P/S If you wanna get an UTF-8 binary example, email me at thangtq@seespace.co and sorry for my Eng :D
I look forward to hearing from you.
